### PR TITLE
Add support for Python 3

### DIFF
--- a/geditpyflakes.plugin
+++ b/geditpyflakes.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=geditpyflakes
 IAge=3
 Name=Pyflakes Plugin, version 3.0.0

--- a/geditpyflakes/__init__.py
+++ b/geditpyflakes/__init__.py
@@ -108,7 +108,7 @@ class PyflakesPlugin(GObject.Object, Gedit.ViewActivatable):
         try:
             with BlackHole():
                 tree = ast.parse(text, filename)
-        except SyntaxError, e:
+        except SyntaxError as e:
             return [PySyntaxError(filename, e.lineno, e.offset, e.text)]
         else:
             w = checker.Checker(tree, filename)


### PR DESCRIPTION
It seems some (all?) versions of gedit above 3.8.3 have trouble with
Python 2 plugins and do not support the "python" loader previously
specified in geditpyflakes.plugin.
